### PR TITLE
chore: promote php-test-quickstart to version 0.0.6

### DIFF
--- a/config-root/namespaces/jx-staging/php-test-quickstart/php-test-quickstart-php-test-quickstart-deploy.yaml
+++ b/config-root/namespaces/jx-staging/php-test-quickstart/php-test-quickstart-php-test-quickstart-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: php-test-quickstart-php-test-quickstart
   labels:
     draft: draft-app
-    chart: "php-test-quickstart-0.0.5"
+    chart: "php-test-quickstart-0.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'php-test-quickstart'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: php-test-quickstart-php-test-quickstart
       containers:
         - name: php-test-quickstart
-          image: "10.97.25.136/klau2005/php-test-quickstart:0.0.5"
+          image: "10.97.25.136/klau2005/php-test-quickstart:0.0.6"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.5
+              value: 0.0.6
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/php-test-quickstart/php-test-quickstart-svc.yaml
+++ b/config-root/namespaces/jx-staging/php-test-quickstart/php-test-quickstart-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: php-test-quickstart
   labels:
-    chart: "php-test-quickstart-0.0.5"
+    chart: "php-test-quickstart-0.0.6"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'php-test-quickstart'

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> php-test-quickstart </a></td>
-	      <td>0.0.5</td>
+	      <td>0.0.6</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -115,13 +115,13 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.5
+    appVersion: 0.0.6
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-08-26T13:11:51Z"
+    firstDeployed: "2021-08-26T13:48:39Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2021-08-26T13:11:51Z"
+    lastDeployed: "2021-08-26T13:48:39Z"
     name: php-test-quickstart
     repositoryName: dev
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
     resourcePath: config-root/namespaces/jx-staging/php-test-quickstart
-    version: 0.0.5
+    version: 0.0.6

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/php-test-quickstart
-  version: 0.0.5
+  version: 0.0.6
   name: php-test-quickstart
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote php-test-quickstart to version 0.0.6

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
