### PR TITLE
chore: promote php-test-quickstart to version 0.0.7

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -3,5 +3,6 @@ helmfiles:
 - path: helmfiles/jx/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
 - path: helmfiles/jx-staging/helmfile.yaml
+- path: helmfiles/jx-production/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx-production
+repositories:
+- name: dev
+  url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
+releases:
+- chart: dev/php-test-quickstart
+  version: 0.0.7
+  name: php-test-quickstart
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
chore: promote php-test-quickstart to version 0.0.7

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
